### PR TITLE
feat: add password reset flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A simple, all-in-one web application designed to help medical school HPREP (Heal
 
     Secure Authentication: Users can securely sign up and log in with an email and password.
 
+    Password Recovery: Admins can reset user passwords and users can request a temporary password via email.
+
     Dynamic Event Creation: Admins can easily create new events, specifying the date, time, description, and number of volunteers needed.
 
     Real-Time Updates: The calendar and event details update in real-time for all users as changes are made, thanks to Firebase.

--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
                 </div>
                 <button type="submit" id="auth-submit-btn" class="w-full bg-indigo-600 text-white py-2 rounded-lg hover:bg-indigo-700 transition font-semibold">Login</button>
                 <button type="button" id="cancel-auth-btn" class="w-full bg-gray-200 text-gray-700 py-2 rounded-lg hover:bg-gray-300 transition font-semibold mt-2">Cancel</button>
+                <button type="button" id="forgot-password-btn" class="w-full text-indigo-600 mt-2">Forgot Password?</button>
             </form>
             <button id="close-auth-modal" class="absolute top-4 right-4 text-gray-500 hover:text-gray-800 text-2xl">&times;</button>
         </div>
@@ -186,6 +187,7 @@
                             <tr>
                                 <th class="px-4 py-2 text-left">Email</th>
                                 <th class="px-4 py-2 text-left">Role</th>
+                                <th class="px-4 py-2 text-left">Actions</th>
                             </tr>
                         </thead>
                         <tbody id="users-table-body"></tbody>
@@ -214,6 +216,21 @@
         </div>
     </div>
 
+
+    <!-- Password Change Modal -->
+    <div id="password-change-modal" class="modal-backdrop hidden">
+        <div class="modal-content bg-white p-8 rounded-xl shadow-2xl w-full max-w-md m-4">
+            <h2 class="text-2xl font-bold mb-6 text-center">Change Password</h2>
+            <div id="password-change-error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg relative mb-4 hidden" role="alert"></div>
+            <form id="password-change-form">
+                <div class="mb-4">
+                    <label for="new-password" class="block text-sm font-medium text-gray-700 mb-1">New Password</label>
+                    <input type="password" id="new-password" required class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500">
+                </div>
+                <button type="submit" class="w-full bg-indigo-600 text-white py-2 rounded-lg hover:bg-indigo-700 transition font-semibold">Update Password</button>
+            </form>
+        </div>
+    </div>
 
     <!-- Firebase SDK -->
     <script type="module">
@@ -259,10 +276,11 @@
             getAuth, 
             createUserWithEmailAndPassword, 
             signInWithEmailAndPassword, 
-            signOut, 
+            signOut,
             onAuthStateChanged,
             signInWithCustomToken,
-            signInAnonymously
+            signInAnonymously,
+            updatePassword
         } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
         import { 
             getFirestore, 
@@ -277,11 +295,13 @@
             arrayRemove,
             getDocs
         } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+        import { getFunctions, httpsCallable } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-functions.js";
 
         // --- App Initialization ---
         const app = initializeApp(finalFirebaseConfig);
         const auth = getAuth(app);
         const db = getFirestore(app);
+        const functions = getFunctions(app);
 
         // --- App ID for Firestore paths ---
         const appId = typeof __app_id !== 'undefined' ? __app_id : 'hprep-scheduler-default';
@@ -359,6 +379,7 @@
             event: document.getElementById('event-modal'),
             admin: document.getElementById('admin-modal'),
             preferences: document.getElementById('preferences-modal'),
+            passwordChange: document.getElementById('password-change-modal'),
         };
 
         function showModal(modalName) {
@@ -418,6 +439,7 @@
 
         document.getElementById('close-auth-modal').addEventListener('click', hideAllModals);
         document.getElementById('cancel-auth-btn').addEventListener('click', hideAllModals);
+        document.getElementById('forgot-password-btn').addEventListener('click', handleForgotPassword);
         document.getElementById('close-event-modal').addEventListener('click', hideAllModals);
         document.getElementById('close-admin-modal').addEventListener('click', hideAllModals);
         document.getElementById('close-preferences-modal').addEventListener('click', hideAllModals);
@@ -449,6 +471,10 @@
                 } else {
                     currentUserRole = 'user';
                     adminPanelBtn.classList.add('hidden');
+                }
+
+                if (userDoc.exists() && userDoc.data().forcePasswordChange) {
+                    showModal('passwordChange');
                 }
 
             } else {
@@ -484,7 +510,14 @@
                         preferences: []
                     });
                 } else {
-                    await signInWithEmailAndPassword(auth, email, password);
+                    const userCredential = await signInWithEmailAndPassword(auth, email, password);
+                    const userDocRef = doc(db, `artifacts/${appId}/users`, userCredential.user.uid);
+                    const userDoc = await getDoc(userDocRef);
+                    if (userDoc.exists() && userDoc.data().forcePasswordChange) {
+                        showModal('passwordChange');
+                        e.target.reset();
+                        return;
+                    }
                 }
                 hideAllModals();
                 e.target.reset();
@@ -493,6 +526,25 @@
                 errorDiv.classList.remove('hidden');
             }
         });
+
+        async function handleForgotPassword() {
+            const email = document.getElementById('email').value;
+            const errorDiv = document.getElementById('auth-error');
+            errorDiv.classList.add('hidden');
+            if (!email) {
+                errorDiv.textContent = 'Please enter your email to reset your password.';
+                errorDiv.classList.remove('hidden');
+                return;
+            }
+            try {
+                const resetFn = httpsCallable(functions, 'requestPasswordReset');
+                await resetFn({ email });
+                alert('Temporary password sent to your email.');
+            } catch (err) {
+                errorDiv.textContent = `Error: ${err.message}`;
+                errorDiv.classList.remove('hidden');
+            }
+        }
         
         // --- Event Modal Logic ---
         let activeEventId = null;
@@ -654,6 +706,9 @@
                                 <option value="admin" ${data.role === 'admin' ? 'selected' : ''}>Admin</option>
                             </select>
                         </td>
+                        <td class="px-4 py-2 border-b">
+                            <button data-uid="${userDoc.id}" data-email="${data.email || ''}" class="reset-password-btn bg-red-500 text-white px-2 py-1 rounded">Reset</button>
+                        </td>
                     `;
                     usersTableBody.appendChild(tr);
                 });
@@ -667,6 +722,24 @@
                         } catch (err) {
                             const errorDiv = document.getElementById('user-management-error');
                             errorDiv.textContent = `Error updating role: ${err.message}`;
+                            errorDiv.classList.remove('hidden');
+                            setTimeout(() => errorDiv.classList.add('hidden'), 3000);
+                        }
+                    });
+                });
+
+                usersTableBody.querySelectorAll('.reset-password-btn').forEach(btn => {
+                    btn.addEventListener('click', async (e) => {
+                        const uid = e.target.dataset.uid;
+                        const email = e.target.dataset.email;
+                        try {
+                            const resetFn = httpsCallable(functions, 'adminResetPassword');
+                            await resetFn({ uid, email });
+                            await setDoc(doc(db, `artifacts/${appId}/users`, uid), { forcePasswordChange: true }, { merge: true });
+                            alert('Temporary password sent to user.');
+                        } catch (err) {
+                            const errorDiv = document.getElementById('user-management-error');
+                            errorDiv.textContent = `Error resetting password: ${err.message}`;
                             errorDiv.classList.remove('hidden');
                             setTimeout(() => errorDiv.classList.add('hidden'), 3000);
                         }
@@ -727,6 +800,22 @@
                 }, 1500);
             } catch (error) {
                 console.error("Error saving preferences:", error);
+                errorDiv.textContent = `Error: ${error.message}`;
+                errorDiv.classList.remove('hidden');
+            }
+        });
+
+        document.getElementById('password-change-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const newPassword = document.getElementById('new-password').value;
+            const errorDiv = document.getElementById('password-change-error');
+            errorDiv.classList.add('hidden');
+            try {
+                await updatePassword(auth.currentUser, newPassword);
+                const userDocRef = doc(db, `artifacts/${appId}/users`, auth.currentUser.uid);
+                await setDoc(userDocRef, { forcePasswordChange: false }, { merge: true });
+                hideAllModals();
+            } catch (error) {
                 errorDiv.textContent = `Error: ${error.message}`;
                 errorDiv.classList.remove('hidden');
             }


### PR DESCRIPTION
## Summary
- allow admins to reset passwords and send temporary credentials
- prompt users to change password after logging in with temp code
- add forgot password option that emails a temporary password

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689522d1546483219c0cfc4fee38972e